### PR TITLE
firstedit: list the most recently created articles

### DIFF
--- a/classes/Query.php
+++ b/classes/Query.php
@@ -1615,7 +1615,7 @@ class Query {
 					break;
 				case 'firstedit':
 					$this->addOrderBy('rev.rev_timestamp');
-					$this->setOrderDir('ASC');
+					$this->setOrderDir('DESC');
 					$this->addTable('revision', 'rev');
 					$this->addSelect(
 						[
@@ -1626,7 +1626,7 @@ class Query {
 						$this->addWhere(
 							[
 								"{$this->tableNames['page']}.page_id = rev.rev_page",
-								"rev.rev_timestamp = (SELECT MAX(rev_aux.rev_timestamp) FROM {$this->tableNames['revision']} AS rev_aux WHERE rev_aux.rev_page=rev.rev_page)"
+								"rev.rev_timestamp = (SELECT MIN(rev_aux.rev_timestamp) FROM {$this->tableNames['revision']} AS rev_aux WHERE rev_aux.rev_page=rev.rev_page)"
 							]
 						);
 					}


### PR DESCRIPTION
Using the firstedit ordermethod should return the most recently created articles, however, without this change it returns the articles with the most recent edit starting ordered by the oldest.
