### PR TITLE
Fixes generated PHP Notice on missing LIKE index

### DIFF
--- a/classes/Parameters.php
+++ b/classes/Parameters.php
@@ -528,7 +528,7 @@ class Parameters extends ParametersData {
 		}
 
 		$data = $this->getParameter('category');
-		if (!is_array($data['LIKE'][$operator])) {
+		if (isset($data['LIKE']) && !is_array($data['LIKE'][$operator])) {
 			$data['LIKE'][$operator] = [];
 		}
 


### PR DESCRIPTION
DPL tries to access a key that sometimes does not exists.