### PR TITLE
move init template page creation to another hook 

### DIFF
--- a/DynamicPageList.hooks.php
+++ b/DynamicPageList.hooks.php
@@ -605,19 +605,9 @@ class DynamicPageListHooks {
 	 * @param	object	[Optional] DatabaseUpdater Object
 	 * @return	boolean	true
 	 */
-	static public function onBeforeInitialize(&$oTitle, &$oArticle, &$output, &$user, $request, $mediaWiki) {
-		//Make sure page "Template:Extension DPL" exists
-		$title = Title::newFromText('Template:Extension DPL');
-
-		if (!$title->exists()) {
-			$article = new Article($title);
-			$article->doEdit(
-				"<noinclude>This page was automatically created. It serves as an anchor page for all '''[[Special:WhatLinksHere/Template:Extension_DPL|invocations]]''' of [http://mediawiki.org/wiki/Extension:DynamicPageList Extension:DynamicPageList (DPL)].</noinclude>",
-				$title,
-				EDIT_NEW | EDIT_FORCE_BOT
-			);
-		}
-
+	static public function onLoadExtensionSchemaUpdates( $updater ) {
+		//start job after update.php is almost done
+		$updater->addPostDatabaseUpdateMaintenance( 'DynamicPageListUpdateMaintenance' );
 		return true;
 	}
 

--- a/DynamicPageList.hooks.php
+++ b/DynamicPageList.hooks.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * 
+ *
  * @file
  * @ingroup Extensions
  * @link http://www.mediawiki.org/wiki/Extension:DynamicPageList_(third-party)	Documentation
- * @author n:en:User:IlyaHaykinson 
- * @author n:en:User:Amgine 
- * @author w:de:Benutzer:Unendlich 
+ * @author n:en:User:IlyaHaykinson
+ * @author n:en:User:Amgine
+ * @author w:de:Benutzer:Unendlich
  * @author m:User:Dangerman <cyril.dangerville@gmail.com>
  * @author m:User:Algorithmix <gero.scholz@gmx.de>
  * @license http://opensource.org/licenses/gpl-license.php GNU Public License
@@ -605,21 +605,7 @@ class DynamicPageListHooks {
 	 * @param	object	[Optional] DatabaseUpdater Object
 	 * @return	boolean	true
 	 */
-	static public function onLoadExtensionSchemaUpdates(DatabaseUpdater $updater = null) {
-		$extDir = __DIR__;
-
-		$updater->addExtensionUpdate([[__CLASS__, 'createDPLTemplate']]);
-
-		return true;
-	}
-
-	/**
-	 * Creates the DPL template when updating.
-	 *
-	 * @access	public
-	 * @return	void
-	 */
-	static public function createDPLTemplate() {
+	static public function onBeforeInitialize(&$oTitle, &$oArticle, &$output, &$user, $request, $mediaWiki) {
 		//Make sure page "Template:Extension DPL" exists
 		$title = Title::newFromText('Template:Extension DPL');
 
@@ -631,6 +617,9 @@ class DynamicPageListHooks {
 				EDIT_NEW | EDIT_FORCE_BOT
 			);
 		}
+
+		return true;
 	}
+
 }
 ?>

--- a/DynamicPageList.php
+++ b/DynamicPageList.php
@@ -60,7 +60,7 @@ if (isset($dplMigrationTesting) && $dplMigrationTesting === true) {
 } else {
 	$wgHooks['ParserFirstCallInit'][]					= 'DynamicPageListHooks::onParserFirstCallInit';
 }
-$wgHooks['LoadExtensionSchemaUpdates'][]				= 'DynamicPageListHooks::onLoadExtensionSchemaUpdates';
+$wgHooks['BeforeInitialize'][]				= 'DynamicPageListHooks::onBeforeInitialize';
 
 //Give sysops permission to use updaterules and deleterules by default.
 if (!isset($wgGroupPermissions['sysop']['dpl_param_update_rules'])) {

--- a/DynamicPageList.php
+++ b/DynamicPageList.php
@@ -54,13 +54,14 @@ $wgAutoloadClasses['DPL\ParametersData']			= "{$extDir}/classes/ParametersData.p
 $wgAutoloadClasses['DPL\Parse']						= "{$extDir}/classes/Parse.php";
 $wgAutoloadClasses['DPL\Query']						= "{$extDir}/classes/Query.php";
 $wgAutoloadClasses['DPL\Variables']					= "{$extDir}/classes/Variables.php";
+$wgAutoloadClasses['DynamicPageListUpdateMaintenance'] = "{$extDir}/classes/DynamicPageListUpdateMaintenance.php";
 
 if (isset($dplMigrationTesting) && $dplMigrationTesting === true) {
 	$wgHooks['ParserFirstCallInit'][]					= 'DynamicPageListHooks::setupMigration';
 } else {
 	$wgHooks['ParserFirstCallInit'][]					= 'DynamicPageListHooks::onParserFirstCallInit';
 }
-$wgHooks['BeforeInitialize'][]				= 'DynamicPageListHooks::onBeforeInitialize';
+$wgHooks['LoadExtensionSchemaUpdates'][]				= 'DynamicPageListHooks::onLoadExtensionSchemaUpdates';
 
 //Give sysops permission to use updaterules and deleterules by default.
 if (!isset($wgGroupPermissions['sysop']['dpl_param_update_rules'])) {

--- a/classes/DynamicPageListUpdateMaintenance.php
+++ b/classes/DynamicPageListUpdateMaintenance.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Check if page is created after all other jobs are done in update.php maintenance script
+ */
+class DynamicPageListUpdateMaintenance extends LoggedUpdateMaintenance {
+
+	protected function doDBUpdates() {
+		//Make sure page "Template:Extension DPL" exists
+		$title = Title::newFromText( 'Template:Extension DPL' );
+
+		if ( !$title->exists() ) {
+			$article = new Article( $title );
+			$article->doEdit(
+			  "<noinclude>This page was automatically created. It serves as an anchor page for all '''[[Special:WhatLinksHere/Template:Extension_DPL|invocations]]''' of [http://mediawiki.org/wiki/Extension:DynamicPageList Extension:DynamicPageList (DPL)].</noinclude>", $title, EDIT_NEW | EDIT_FORCE_BOT
+			);
+		}
+	}
+
+	protected function getUpdateKey() {
+		return 'dynamic-page-list-update-maintenance';
+	}
+
+}

--- a/extension.json
+++ b/extension.json
@@ -39,14 +39,15 @@
 		"DPL\\ParametersData": "classes/ParametersData.php",
 		"DPL\\Parse": "classes/Parse.php",
 		"DPL\\Query": "classes/Query.php",
-		"DPL\\Variables": "classes/Variables.php"
+		"DPL\\Variables": "classes/Variables.php",
+		"DynamicPageListUpdateMaintenance": "classes/DynamicPageListUpdateMaintenance.php"
 	},
 	"Hooks": {
 		"ParserFirstCallInit": [
 			"DynamicPageListHooks::onParserFirstCallInit"
 		],
 		"BeforeInitialize": [
-			"DynamicPageListHooks::onBeforeInitialize"
+			"DynamicPageListHooks::onLoadExtensionSchemaUpdates"
 		]
 	},
 	"config": {

--- a/extension.json
+++ b/extension.json
@@ -45,8 +45,8 @@
 		"ParserFirstCallInit": [
 			"DynamicPageListHooks::onParserFirstCallInit"
 		],
-		"LoadExtensionSchemaUpdates": [
-			"DynamicPageListHooks::onLoadExtensionSchemaUpdates"
+		"BeforeInitialize": [
+			"DynamicPageListHooks::onBeforeInitialize"
 		]
 	},
 	"config": {


### PR DESCRIPTION
to prevent error on schemaupdate in case that tables are not created yet in onPageContentSave hooks of other extensions