### PR TITLE
improve performance of lastrevisionbefore/firstrevisionsince for small result sets

### DIFF
--- a/classes/Query.php
+++ b/classes/Query.php
@@ -1018,6 +1018,13 @@ class Query {
 				'rev.rev_timestamp'
 			]
 		);
+		// tell the query optimizer not to look at rows that the following subquery will filter out anyway
+		$this->addWhere(
+			[
+				$this->tableNames['page'].'.page_id = rev.rev_page',
+				'rev.rev_timestamp >= '.$this->DB->addQuotes($option)
+			]
+		);
 		$this->addWhere(
 			[
 				$this->tableNames['page'].'.page_id = rev.rev_page',
@@ -1138,6 +1145,13 @@ class Query {
 	private function _lastrevisionbefore($option) {
 		$this->addTable('revision', 'rev');
 		$this->addSelect(['rev.rev_id', 'rev.rev_timestamp']);
+		// tell the query optimizer not to look at rows that the following subquery will filter out anyway
+		$this->addWhere(
+			[
+				$this->tableNames['page'].'.page_id = rev.rev_page',
+				'rev.rev_timestamp < '.$this->DB->addQuotes($option)
+			]
+		);
 		$this->addWhere(
 			[
 				$this->tableNames['page'].'.page_id = rev.rev_page',


### PR DESCRIPTION
MySQL's query optimizer isn't quite smart enough to look at the subqueries generated for lastrevisionbefore and firstrevisionsince.  This PR adds an extra WHERE clause to give it a hint.  In my staging environment, this causes a drastic performance improvement (1.9s before vs .003s after) when picking a date that filters out most revisions.  (e.g. firstrevisionsince=2017-01-01)