### PR TITLE
specify sort direction for each column in ORDER BY clauses

### DIFF
--- a/classes/Query.php
+++ b/classes/Query.php
@@ -235,9 +235,6 @@ class Query {
 			}
 			if (count($this->orderBy)) {
 				$options['ORDER BY'] = $this->orderBy;
-				$_lastOrder = array_pop($options['ORDER BY']);
-				$_lastOrder .= " ".$this->direction;
-				$options['ORDER BY'][] = $_lastOrder;
 			}
 		}
 		if ($this->parameters->getParameter('goal') == 'categories') {
@@ -495,7 +492,11 @@ class Query {
 		if (empty($orderBy)) {
 			throw new \MWException(__METHOD__.': An empty order by clause was passed.');
 		}
-		$this->orderBy[] = $orderBy;
+		if (!preg_match('/(asc(ending)?|desc(ending)?)$/i', $orderBy)) {
+			$this->orderBy[] = "$orderBy " . $this->direction;
+		}	else {
+			$this->orderBy[] = $orderBy;
+		}
 		return true;
 	}
 
@@ -823,8 +824,8 @@ class Query {
 				'rev.rev_timestamp'
 			]
 		);
-		$this->addOrderBy('rev.rev_id');
 		$this->setOrderDir('DESC');
+		$this->addOrderBy('rev.rev_id');
 		$this->addWhere(
 			[
 				$this->tableNames['page'].'.page_id = rev.rev_page',
@@ -848,8 +849,8 @@ class Query {
 				'rev.rev_timestamp'
 			]
 		);
-		$this->addOrderBy('rev.rev_id');
 		$this->setOrderDir('DESC');
+		$this->addOrderBy('rev.rev_id');
 		$this->addWhere(
 			[
 				$this->tableNames['page'].'.page_id = rev.rev_page',


### PR DESCRIPTION
Without this fix, any queries that contain multiple fields in their ORDER BY clause will only have the last field ordered in a non-default direction.  This isn't useful because generally the first field is the most important.

My particular use case was to create a list of the 10 most-recently-edited pages using the query below.  Without this fix, DPL's orderby doesn't have any apparent effect.

DPL:
```
{{#dpl:
|namespace=
|allowcachedresults=false
|ordermethod=lastedit
|order=descending
|allrevisionssince=2017-01-01
|debug=0
|count=10
}}
```

SQL (ORDER BY is at the end of the query):
```
 SELECT DISTINCT rev.rev_timestamp,rev.rev_id,`page`.page_namespace AS `page_namespace`,`page`.page_id AS `page_id`,`page`.page_title AS `page_title` FROM `revision` `rev`,`page` WHERE (`page`.page_id = rev.rev_page) AND (rev.rev_timestamp = (SELECT MAX(rev_aux.rev_timestamp) FROM `revision` AS rev_aux WHERE rev_aux.rev_page = rev.rev_page)) AND `page`.page_is_redirect = '0' AND `page`.page_namespace = '0' AND (`page`.page_id = rev.rev_page) AND (rev.rev_timestamp >= '20170101000000') ORDER BY rev.rev_timestamp,rev.rev_id DESC LIMIT 10
```