### PR TITLE
Relative timestamps

### DIFF
--- a/classes/Parameters.php
+++ b/classes/Parameters.php
@@ -123,11 +123,22 @@ class Parameters extends ParametersData {
 
 			//Timestamps
 			if (array_key_exists('timestamp', $parameterData) && $parameterData['timestamp'] === true) {
-				$option = str_pad(preg_replace('#[^0-9]#', '', $option), 14, '0');
-				$option = wfTimestamp(TS_MW, $option);
+				switch ($option) {
+					case 'today':
+					case 'last hour':
+					case 'last day':
+					case 'last week':
+					case 'last month':
+					case 'last year':
+						break;
+					default:
+						$option = str_pad(preg_replace('#[^0-9]#', '', $option), 14, '0');
+						$option = wfTimestamp(TS_MW, $option);
 
-				if ($option === false) {
-					$success = false;
+						if ($option === false) {
+							$success = false;
+						}
+						break;
 				}
 			}
 

--- a/classes/Query.php
+++ b/classes/Query.php
@@ -2064,32 +2064,39 @@ class Query {
 	 * @return	integer
 	 */
 	private function _convertTimestamp($inputDate) {
-		if (is_numeric($inputDate)) {
-			return $this->DB->addQuotes($inputDate);
-		}
+		$timestamp = $inputDate;
 		switch ($inputDate) {
 			case 'today':
-				return date('YmdHis');
+				$timestamp = date('YmdHis');
+				break;
 			case 'last hour':
 				$date = new \DateTime();
 				$date->sub(new \DateInterval('P1H'));
-				return $date->format('YmdHis');
+				$timestamp = $date->format('YmdHis');
+				break;
 			case 'last day':
 				$date = new \DateTime();
 				$date->sub(new \DateInterval('P1D'));
-				return $date->format('YmdHis');
+				$timestamp = $date->format('YmdHis');
+				break;
 			case 'last week':
 				$date = new \DateTime();
 				$date->sub(new \DateInterval('P7D'));
-				return $date->format('YmdHis');
+				$timestamp = $date->format('YmdHis');
+				break;
 			case 'last month':
 				$date = new \DateTime();
 				$date->sub(new \DateInterval('P1M'));
-				return $date->format('YmdHis');
+				$timestamp = $date->format('YmdHis');
+				break;
 			case 'last year':
 				$date = new \DateTime();
 				$date->sub(new \DateInterval('P1Y'));
-				return $date->format('YmdHis');
+				$timestamp = $date->format('YmdHis');
+				break;
+		}
+		if (is_numeric($timestamp)) {
+			return $this->DB->addQuotes($timestamp);
 		}
 	}
 }

--- a/classes/Query.php
+++ b/classes/Query.php
@@ -828,7 +828,7 @@ class Query {
 		$this->addWhere(
 			[
 				$this->tableNames['page'].'.page_id = rev.rev_page',
-				'rev.rev_timestamp < '.$this->DB->addQuotes($option)
+				'rev.rev_timestamp < '.$this->_convertTimestamp($option)
 			]
 		);
 	}
@@ -853,7 +853,7 @@ class Query {
 		$this->addWhere(
 			[
 				$this->tableNames['page'].'.page_id = rev.rev_page',
-				'rev.rev_timestamp >= '.$this->DB->addQuotes($option)
+				'rev.rev_timestamp >= '.$this->_convertTimestamp($option)
 			]
 		);
 	}
@@ -1021,7 +1021,7 @@ class Query {
 		$this->addWhere(
 			[
 				$this->tableNames['page'].'.page_id = rev.rev_page',
-				'rev.rev_timestamp = (SELECT MIN(rev_aux_snc.rev_timestamp) FROM '.$this->tableNames['revision'].' AS rev_aux_snc WHERE rev_aux_snc.rev_page=rev.rev_page AND rev_aux_snc.rev_timestamp >= '.$this->DB->addQuotes($option).')'
+				'rev.rev_timestamp = (SELECT MIN(rev_aux_snc.rev_timestamp) FROM '.$this->tableNames['revision'].' AS rev_aux_snc WHERE rev_aux_snc.rev_page=rev.rev_page AND rev_aux_snc.rev_timestamp >= '.$this->_convertTimestamp($option).')'
 			]
 		);
 	}
@@ -1141,7 +1141,7 @@ class Query {
 		$this->addWhere(
 			[
 				$this->tableNames['page'].'.page_id = rev.rev_page',
-				'rev.rev_timestamp = (SELECT MAX(rev_aux_bef.rev_timestamp) FROM '.$this->tableNames['revision'].' AS rev_aux_bef WHERE rev_aux_bef.rev_page=rev.rev_page AND rev_aux_bef.rev_timestamp < '.$this->DB->addQuotes($option).')'
+				'rev.rev_timestamp = (SELECT MAX(rev_aux_bef.rev_timestamp) FROM '.$this->tableNames['revision'].' AS rev_aux_bef WHERE rev_aux_bef.rev_page=rev.rev_page AND rev_aux_bef.rev_timestamp < '.$this->_convertTimestamp($option).')'
 			]
 		);
 	}
@@ -2054,6 +2054,43 @@ class Query {
 			$where .= implode(' OR ', $ors).'))';
 		}
 		$this->addWhere($where);
+	}
+
+	/**
+	 * Helper method to handle timestamps.
+	 *
+	 * @access	private
+	 * @param	mixed int or string
+	 * @return	integer
+	 */
+	private function _convertTimestamp($inputDate) {
+		if (is_numeric($inputDate)) {
+			return $this->DB->addQuotes($inputDate);
+		}
+		switch ($inputDate) {
+			case 'today':
+				return date('YmdHis');
+			case 'last hour':
+				$date = new \DateTime();
+				$date->sub(new \DateInterval('P1H'));
+				return $date->format('YmdHis');
+			case 'last day':
+				$date = new \DateTime();
+				$date->sub(new \DateInterval('P1D'));
+				return $date->format('YmdHis');
+			case 'last week':
+				$date = new \DateTime();
+				$date->sub(new \DateInterval('P7D'));
+				return $date->format('YmdHis');
+			case 'last month':
+				$date = new \DateTime();
+				$date->sub(new \DateInterval('P1M'));
+				return $date->format('YmdHis');
+			case 'last year':
+				$date = new \DateTime();
+				$date->sub(new \DateInterval('P1Y'));
+				return $date->format('YmdHis');
+		}
 	}
 }
 ?>


### PR DESCRIPTION
DPL3 doesn't currently have a way to filter revisions relative to the current time (e.g. "get me all revisions in the last hour").  This patch provides one way to implement that feature.

My motivation is that I'd like to build a list of the most recent 10 edits via DPL.  This list needs to be regenerated every time it's viewed (allowcachedresults=false) and it will be on our front page, so performance is important.  It would technically be possible to use allrevisionsbefore=2017-03-01|count=10 but that will gradually slow down unless the allrevisionsbefore date is updated manually.  With this patch, it's possible to create a list of the most recent edits that will always be efficient.

The patch adds the following timestamps: today, last hour, last day, last week, last month, last year.  They're converted into numeric timestamps before being passed to the database.

I'm not married to the current format (e.g. allrevisionssince=last day).  I toyed around with the syntax and this seems to be the cleanest.  It'd also be possible to expose the value passed to DateInterval directly (e.g. allrevisionssince=P1M3D2H for 1 month, 3 days and 2 hours) but that's less friendly and exposes implementation details.  Suggestions are welcome.

@Alexia, I've also got an [all-fixes](https://github.com/Alexia/DynamicPageList/compare/master...cotto:all-fixes) branch in my clone which contains all 3 changes (revision filter efficiency, sort direction and this change) if you want to merge everything in one shot.  There's a minor (and easily-resolved) merge conflict that you'll run into if you merge them one-by-one.