### PR TITLE
addeditdate doesn't do what it says

### DIFF
--- a/classes/Query.php
+++ b/classes/Query.php
@@ -779,6 +779,23 @@ class Query {
 	}
 
 	/**
+	 * Set SQL for 'addeditdate' parameter.
+	 *
+	 * @access	private
+	 * @param	mixed	Parameter Option
+	 * @return	void
+	 */
+	private function _addeditdate($option) {
+		$this->addTable('revision', 'rev');
+		$this->addSelect(['rev.rev_timestamp']);
+		$this->addWhere(
+			[
+				$this->tableNames['page'].'.page_id = rev.rev_page',
+			]
+		);
+	}
+
+	/**
 	 * Set SQL for 'addpagecounter' parameter.
 	 *
 	 * @access	private


### PR DESCRIPTION
In the following query, %DATE% won't contain an article's edit date, even though `addeditdate=true` and `ordermethod=lastedit` are part of the query.  With this patch, addeditdate acts as one would expect.  I'm not sure how addeditdate ever worked so there's a chance that this is just a misunderstanding on my part.

```
{{#dpl: 
 title={{PAGENAMEE}}
 |namespace={{NAMESPACE}}
 |skipthispage=false
 |addeditdate=true
 |ordermethod=lastedit
 |userdateformat=U
 |format=,%DATE%,,
 |allowcachedresults=false
 |count=1
 |debug=4
}
```

edit: all of this happens on master as of 3.1.0.