### PR TITLE
Use different symbols in %ARGS% to avoid parser conflicts

### DIFF
--- a/classes/LST.php
+++ b/classes/LST.php
@@ -615,7 +615,7 @@ class LST {
 							if ($catlist != '') {
 								$argChain .= "|%CATLIST%=$catlist";
 							}
-							$argChain .= '|%DATE%=' . $date . '|%USER%=' . $user . '|%ARGS%=' . str_replace('|', '§', preg_replace('/[}]+/', '}', preg_replace('/[{]+/', '{', substr($invocation, strlen($template2) + 2)))) . '}}';
+							$argChain .= '|%DATE%=' . $date . '|%USER%=' . $user . '|%ARGS%=' . str_replace('|', '§', str_replace('}', '❵', str_replace('{', '❴', substr($invocation, strlen($template2) + 2)))) . '}}';
 							$output[++$n] = $parser->preprocess($argChain, $parser->mTitle, $parser->mOptions);
 						}
 						break;


### PR DESCRIPTION
With recent versions of MediaWiki, there is this thing called [LanguageConverter](https://www.mediawiki.org/wiki/Writing_systems/LanguageConverter) which has [a syntax](https://www.mediawiki.org/wiki/Writing_systems/Syntax) that looks like this:

```
-{ text }-
-{ flag | variant1 : text1 ; variant2 : text2 ; }-
```

Due to the parser being rather bad at parsing this *correctly* (which I personally consider [a bug](https://phabricator.wikimedia.org/T189095)), this causes problems when that syntax is used partially. In particular, the following currently breaks, preventing any template inclusion:

```
{{Test| -{ }}
```

The problem is that with DPL and custom output formats, there is this `%ARGS%` parameter that is being appended to the template call. That `%ARGS%` parameter contains the original template invocation but with some parser syntax replaced by something that will not trigger the normal parser rules. In particular, subsequent curly braces are replaced by a single one, turning a nested template call `{{foo}}` into plain text `{foo}`.

So far so good. However, when the nested template call is being prefixed by a minus, i.e. `-{{foo}}`, then this gets converted to `-{foo}` and is added as %ARGS% to the included template call. And this is exactly of the format from above that triggers the LanguageConverter but breaks the parser. So this will effectively break DPL at this point.

For example, assuming there is a `Template:Example` and some page calls the template like this:

```
{{Example| arg = -{{foo|test1}} }}
```

Now, let’s create a simple DPL query for that:

```
{{ #dpl:
| debug = 5
| allowcachedresults = false
| uses = Template:Example
| mode = userformat
| include = {Example}.dpl
}}
```

This results in the following *plain text* result:

```
{{Example.dpl| arg = -<strong>test1</strong> |%PAGE%=Bar|%TITLE%=Bar|%DATE%=|%USER%=|%ARGS%=§ arg = -{foo§test1} }}
```

Since there is the `-{` sequence, this breaks the parser and the whole `Example.dpl` template call is not being evaluated, breaking the DPL result.

---

To me, the parser is obviously broken there, since it should actually make sure that there’s also a closing `}-`. I have [opened an issue about this](https://phabricator.wikimedia.org/T189095) but I don’t really expect any changes there soon. So I would like to see this fixed on the DPL end instead. This pull request does exactly that.

I did not find anything about what the `%ARGS%` parameter is used for. It is not actually documented in [the list of arguments being passed to surrogate templates](https://help.gamepedia.com/DPL:Parameters:_Controlling_Output_Volume#include_contents_related_to_templates), and it’s also not included in [the list of magic variables](https://help.gamepedia.com/DPL:Parameters:_Controlling_Output_Format#format). So I would assume that this is mostly for debugging purposes, making the actual format not that critical. As such, we should be fine to change the format to avoid this parser error.

I have chosen to replace the curly braces by [MEDIUM LEFT CURLY BRACKET ORNAMENT](http://www.fileformat.info/info/unicode/char/2774/index.htm) and [MEDIUM RIGHT CURLY BRACKET ORNAMENT](http://www.fileformat.info/info/unicode/char/2775/index.htm) which happen to be Unicode character that look very similar to the original curly braces. Since these are completely unknown to the parser, it’s also safe to do a simple string replace here instead of collapsing subsequent curly braces with regular expressions.

I have tested this in my development environment and the change is working fine. Unless there is an actual use for `%ARGS%`, I don’t expect this to be of any real impact. So it would be a very simple workaround for the parser problem.

Btw. I would like to take this opportunity to thank you for taking over DPL and giving it a future! :)