### PR TITLE
Use LoggedUpdateMaintenance to create Template

### DIFF
--- a/DynamicPageList.hooks.php
+++ b/DynamicPageList.hooks.php
@@ -605,7 +605,7 @@ class DynamicPageListHooks {
 	static public function onLoadExtensionSchemaUpdates(DatabaseUpdater $updater = null) {
 		$extDir = __DIR__;
 
-		$updater->addExtensionUpdate([[__CLASS__, 'createDPLTemplate']]);
+		$updater->addPostDatabaseUpdateMaintenance( 'DPL\\CreateTemplateUpdateMaintenance' );
 
 		$db = wfGetDB(DB_MASTER);
 		if (!$db->tableExists('dpl_clview')) {
@@ -613,27 +613,6 @@ class DynamicPageListHooks {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Creates the DPL template when updating.
-	 *
-	 * @access	public
-	 * @return	void
-	 */
-	static public function createDPLTemplate() {
-		//Make sure page "Template:Extension DPL" exists
-		$title = Title::newFromText('Template:Extension DPL');
-
-		if (!$title->exists()) {
-			$page = WikiPage::factory($title);
-			$pageContent = ContentHandler::makeContent("<noinclude>This page was automatically created. It serves as an anchor page for all '''[[Special:WhatLinksHere/Template:Extension_DPL|invocations]]''' of [http://mediawiki.org/wiki/Extension:DynamicPageList Extension:DynamicPageList (DPL)].</noinclude>", $title);
-			$page->doEditContent(
-				$pageContent,
-				$title,
-				EDIT_NEW | EDIT_FORCE_BOT
-			);
-		}
 	}
 }
 ?>

--- a/classes/CreateTemplateUpdateMaintenance.php
+++ b/classes/CreateTemplateUpdateMaintenance.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DPL;
+
+use LoggedUpdateMaintenance;
+use Title;
+use WikiPage;
+use ContentHandler;
+
+/*
+ * Creates the DPL template when updating.
+ */
+class CreateTemplateUpdateMaintenance extends LoggedUpdateMaintenance {
+
+	protected function doDBUpdates() {
+		//Make sure page "Template:Extension DPL" exists
+		$title = Title::newFromText('Template:Extension DPL');
+
+		if (!$title->exists()) {
+			$page = WikiPage::factory($title);
+			$pageContent = ContentHandler::makeContent("<noinclude>This page was automatically created. It serves as an anchor page for all '''[[Special:WhatLinksHere/Template:Extension_DPL|invocations]]''' of [http://mediawiki.org/wiki/Extension:DynamicPageList Extension:DynamicPageList (DPL)].</noinclude>", $title);
+			$page->doEditContent(
+				$pageContent,
+				$title,
+				EDIT_NEW | EDIT_FORCE_BOT
+			);
+		}
+	}
+
+	protected function getUpdateKey() {
+		return 'dynamic-page-list-create-template';
+	}
+
+}

--- a/extension.json
+++ b/extension.json
@@ -31,6 +31,7 @@
 		"DynamicPageListHooks": "DynamicPageList.hooks.php",
 		"DPL\\Article": "classes/Article.php",
 		"DPL\\Config": "classes/Config.php",
+		"DPL\\CreateTemplateUpdateMaintenance": "classes/CreateTemplateUpdateMaintenance.php",
 		"DPL\\DynamicPageList": "classes/DynamicPageList.php",
 		"DPL\\Logger": "classes/Logger.php",
 		"DPL\\ListMode": "classes/ListMode.php",


### PR DESCRIPTION
Making modifications to wikipages in the `LoadExtensionSchemaUpdates` hook
can be problematic, as other extensions may bind to hooks like
`PageContentSaveComplete`. Those other extensions then might access the
database which is not up to date yet, causing an exception.

Using a `LoggedUpdateMaintenance` script makes sure the modifications to
wikipages occur _after_ the database has been fully updated.