### PR TITLE
Added permission (Lockdown) check on db query

### DIFF
--- a/classes/Query.php
+++ b/classes/Query.php
@@ -205,22 +205,23 @@ class Query {
 		if (is_array($wgNonincludableNamespaces) && count($wgNonincludableNamespaces)) {
 			// Check if Lockdown installed
 			if(!empty($wgNamespacePermissionLockdown)) {
-				$addNotWhere = array();
+				$addNotWhere = [];
 				// Check for each "NonincludableNamespace" if permission to read is granted for current user (group)
-				foreach($wgNonincludableNamespaces as $ns_id_i) {
-					if(array_key_exists($ns_id_i,$wgNamespacePermissionLockdown)) {
+				foreach ($wgNonincludableNamespaces as $ns_id_i) {
+					if (array_key_exists($ns_id_i, $wgNamespacePermissionLockdown)) {
 						// Check for "read" permissions of current user on NonincludableNamespaces, not empty = read permissions!
-						$outp = array_intersect($wgNamespacePermissionLockdown[$ns_id_i]['read'],$wgUser->getGroups());
-						if(empty($outp)) $addNotWhere[] = $ns_id_i;
+						$outp = array_intersect($wgNamespacePermissionLockdown[$ns_id_i]['read'], $wgUser->getGroups());
+						if (empty($outp)) {
+							$addNotWhere[] = $ns_id_i;
+						}
 					}
 				}
-			}
-			else {
+			} else {
 				// If Lockdown not installed take the normal NonincludableNamespaces
 				$addNotWhere = $wgNonincludableNamespaces;
 			}
 			// Recheck if still NS in (new) array, than kill all namespaces that shouldn't be included
-			if(is_array($addNotWhere) && count($addNotWhere)) {
+			if (is_array($addNotWhere) && count($addNotWhere)) {
 				$this->addNotWhere(
 					[
 						$this->tableNames['page'].'.page_namespace' => $addNotWhere // Changed var

--- a/classes/Query.php
+++ b/classes/Query.php
@@ -204,15 +204,15 @@ class Query {
 		//Always add nonincludeable namespaces.
 		if (is_array($wgNonincludableNamespaces) && count($wgNonincludableNamespaces)) {
 			// Check if Lockdown installed
-			if(!empty($wgNamespacePermissionLockdown)) {
+			if (!empty($wgNamespacePermissionLockdown)) {
 				$addNotWhere = [];
 				// Check for each "NonincludableNamespace" if permission to read is granted for current user (group)
-				foreach ($wgNonincludableNamespaces as $ns_id_i) {
-					if (array_key_exists($ns_id_i, $wgNamespacePermissionLockdown)) {
+				foreach ($wgNonincludableNamespaces as $namespaceId) {
+					if (isset($wgNamespacePermissionLockdown[$namespaceId])) {
 						// Check for "read" permissions of current user on NonincludableNamespaces, not empty = read permissions!
-						$outp = array_intersect($wgNamespacePermissionLockdown[$ns_id_i]['read'], $wgUser->getGroups());
+						$outp = array_intersect($wgNamespacePermissionLockdown[$namespaceId]['read'], $wgUser->getGroups());
 						if (empty($outp)) {
-							$addNotWhere[] = $ns_id_i;
+							$addNotWhere[] = $namespaceId;
 						}
 					}
 				}

--- a/classes/Query.php
+++ b/classes/Query.php
@@ -168,7 +168,11 @@ class Query {
 	 */
 	public function buildAndSelect($calcRows = false) {
 		global $wgNonincludableNamespaces;
-
+		// Get namespace permission from Lockdown extension
+		global $wgNamespacePermissionLockdown;
+		// Get user object from current logged in user
+		global $wgUser;
+		
 		$options = [];
 
 		$parameters = $this->parameters->getAllParameters();
@@ -199,11 +203,30 @@ class Query {
 		}
 		//Always add nonincludeable namespaces.
 		if (is_array($wgNonincludableNamespaces) && count($wgNonincludableNamespaces)) {
-			$this->addNotWhere(
-				[
-					$this->tableNames['page'] . '.page_namespace' => $wgNonincludableNamespaces
-				]
-			);
+			// Check if Lockdown installed
+			if(!empty($wgNamespacePermissionLockdown)) {
+				$addNotWhere = array();
+				// Check for each "NonincludableNamespace" if permission to read is granted for current user (group)
+				foreach($wgNonincludableNamespaces as $ns_id_i) {
+					if(array_key_exists($ns_id_i,$wgNamespacePermissionLockdown)) {
+						// Check for "read" permissions of current user on NonincludableNamespaces, not empty = read permissions!
+						$outp = array_intersect($wgNamespacePermissionLockdown[$ns_id_i]['read'],$wgUser->getGroups());
+						if(empty($outp)) $addNotWhere[] = $ns_id_i;
+					}
+				}
+			}
+			else {
+				// If Lockdown not installed take the normal NonincludableNamespaces
+				$addNotWhere = $wgNonincludableNamespaces;
+			}
+			// Recheck if still NS in (new) array, than kill all namespaces that shouldn't be included
+			if(is_array($addNotWhere) && count($addNotWhere)) {
+				$this->addNotWhere(
+					[
+						$this->tableNames['page'].'.page_namespace' => $addNotWhere // Changed var
+					]
+				);
+			}
 		}
 
 		if ($this->offset !== false) {


### PR DESCRIPTION
I made DPL work with the Lockdown extension. Now DPL only shows Articles from Namespaces that the current user has permission to "read". As I see it, the changes shouldn't touch any other functions or conflict with any other extension.

Just added the user-object (made $wgUser global - I din't know how to get the object with another call) and the Lockdown-array ($wgNamespacePermissionLockdown - also global). Then I compare the "read" part of the Lockdown-array (should hold all groups with "read" permission) against the current user groups and add all namespaces to the $addNotWhere array that shouldn't be seen.

It's not that pretty but works perfectly fine on our wikis.